### PR TITLE
Remove ticket sale and mark tickets as sold out

### DIFF
--- a/Public/styles/app.css
+++ b/Public/styles/app.css
@@ -155,6 +155,7 @@ a, a:hover, a:focus {
 .hero {
   overflow: hidden;
   position: relative;
+  margin-bottom: 40px;
 }
 
 .brand {

--- a/Resources/Views/layout/navigation.leaf
+++ b/Resources/Views/layout/navigation.leaf
@@ -44,10 +44,6 @@
             <li class="buy-ticket">
                 <a href="/tickets">Buy Tickets</a>
                 <span class="underline"></span>
-                <div class="flash-sale-pointer text-center">
-                    <strong>FLASH SALE</strong>
-                    <br /> 25% OFF
-                </div>
             </li>
         </ul>
     </div>

--- a/Resources/Views/layout/navigation.leaf
+++ b/Resources/Views/layout/navigation.leaf
@@ -42,7 +42,7 @@
                 <span class="underline"></span>
             </li>
             <li class="buy-ticket">
-                <a href="/tickets">Buy Tickets</a>
+                <a href="/tickets"><strike>Buy Tickets</strike></a>
                 <span class="underline"></span>
             </li>
         </ul>
@@ -77,7 +77,7 @@
             <span class="underline"></span>
         </li>
         <li class="buy-ticket">
-            <a href="/tickets" target="_blank">Buy Tickets</a>
+            <a href="/tickets" target="_blank"><strike>Buy Tickets</strike></a>
             <span class="underline"></span>
         </li>
     </ul>

--- a/Resources/Views/pages/home.leaf
+++ b/Resources/Views/pages/home.leaf
@@ -16,16 +16,6 @@
           <h1 class="text-center m-b-0">Server-Side Swift Conference</h1>
           <h2 class="text-center m-t-0">12th-14th September 2018. Berlin, Germany</h2>
 
-          <div class="row">
-            <div class="col-xs-12 col-sm-8 col-sm-offset-2">
-              <div class="buy-tickets">
-                <p class="text-center">
-                  <a href="/tickets" class="btn btn-default btn-sss">BUY TICKETS</a>
-                </p>
-              </div>
-            </div>
-          </div>
-
         </div>
       </div>
     </div>

--- a/Resources/Views/pages/tickets.leaf
+++ b/Resources/Views/pages/tickets.leaf
@@ -12,9 +12,9 @@
 
 <h3 class="flash-sale alert alert-danger text-center" style="max-width: 900px; margin: 0 auto; background: linear-gradient(to right, #()F88A36 , #()FD2020); color: #()ffffff;">
 
-                            Get the last tickets with 25% OFF!
-                            <br /> <small style="color: #()ffffff;">Regular Ticket: <strong>250€</strong> / Workshop Ticket: <strong>75€</strong></small>
-                            <br /> <span style="color: #()ffffff; font-size: 13px;">Use the discount code: "FLASHSALE".</span>
+                            Thank you to everyone who has bought a ticket - we are now sold out!
+                            <br>
+                            We can't wait to see you all
                         </h3>
                     </div>
                 </div>


### PR DESCRIPTION
I've left the page available for now in case we bring back the waiting list - I thought it was there? If not we can just kill the whole page